### PR TITLE
Care package-lock.json to be repeatable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,13 @@ jobs:
   build:
     docker:
       - image: circleci/golang:1.12
-    environment:
-      GO111MODULE: 'on'
     steps:
       - run:
           name: Install dependencies
           command: |
             go env
             go get -u github.com/go-bindata/go-bindata/go-bindata
-            go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.26.0
             go mod download
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ jobs:
   build:
     docker:
       - image: circleci/golang:1.12
+    environment:
+      GO111MODULE: 'on'
     steps:
       - run:
           name: Install dependencies

--- a/assets/aws-device-farm/workflows/1-install.bash
+++ b/assets/aws-device-farm/workflows/1-install.bash
@@ -28,7 +28,7 @@ install_ios() {
 
 	echo "Install ios-deploy into $DEVFARM_AGENT_IOS_DEPLOY_ROOT"
 	(cd "$DEVFARM_AGENT_IOS_DEPLOY_ROOT"
-		npm install
+		npm ci
 	)
 
 	echo "Verify ios-deploy"


### PR DESCRIPTION
```
ios-deploy: start: "/tmp/scratchc9YHM0.scratch/test-packagerFdDOn/ios-deploy-agent/node_modules/.bin/ios-deploy" "--verbose" "--id" "00008020-000A298C0A08002E" "--noninteractive" "--noinstall" "--bundle" "/Users/device-farm/SUT.app" "--args" ""
ios-deploy: failed to start ios-deploy: fork/exec /tmp/scratchc9YHM0.scratch/test-packagerFdDOn/ios-deploy-agent/node_modules/.bin/ios-deploy: no such file or directory
app forever: failed to launch app: fork/exec /tmp/scratchc9YHM0.scratch/test-packagerFdDOn/ios-deploy-agent/node_modules/.bin/ios-deploy: no such file or directory
fork/exec /tmp/scratchc9YHM0.scratch/test-packagerFdDOn/ios-deploy-agent/node_modules/.bin/ios-deploy: no such file or directory
```