### PR TITLE
Ignore io.ErrClosedPipe from adb

### DIFF
--- a/.idea/runConfigurations/go_test_devfarm.xml
+++ b/.idea/runConfigurations/go_test_devfarm.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="go test devfarm" type="GoTestRunConfiguration" factoryName="Go Test" nameIsGenerated="true">
+    <module name="devfarm" />
+    <working_directory value="$PROJECT_DIR$/" />
+    <go_parameters value="-i" />
+    <framework value="gotest" />
+    <kind value="DIRECTORY" />
+    <package value="github.com/dena/devfarm" />
+    <directory value="$PROJECT_DIR$/" />
+    <filePath value="$PROJECT_DIR$/" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/cmd/core/contextio/reader.go
+++ b/cmd/core/contextio/reader.go
@@ -1,0 +1,39 @@
+package contextio
+
+import (
+	"context"
+	"io"
+)
+
+type Reader struct {
+	reader io.Reader
+	closer io.Closer
+	ctx    context.Context
+}
+
+var _ io.ReadCloser = &Reader{}
+
+func NewReader(reader io.Reader, closer io.Closer, ctx context.Context) *Reader {
+	contextReader := &Reader{ctx: ctx, closer: closer, reader: reader}
+
+	go func() {
+		// NOTE: Prevent goroutines leak.
+		doneCh := ctx.Done()
+		if doneCh != nil {
+			<-doneCh
+			_ = contextReader.Close()
+		}
+	}()
+	return contextReader
+}
+
+func (r *Reader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.reader.Read(p)
+}
+
+func (r *Reader) Close() error {
+	return r.closer.Close()
+}

--- a/cmd/core/contextio/reader_test.go
+++ b/cmd/core/contextio/reader_test.go
@@ -1,0 +1,58 @@
+package contextio
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"testing"
+	"time"
+)
+
+func TestReaderRead(t *testing.T) {
+	internalReader, internalWriter := io.Pipe()
+	reader := NewReader(internalReader, internalReader, context.Background())
+
+	go func() {
+		time.Sleep(time.Duration(100) * time.Millisecond)
+		_, _ = io.WriteString(internalWriter, "Hello")
+		_ = internalWriter.CloseWithError(io.EOF)
+	}()
+
+	res, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Logf("wrote: %s", res)
+		t.Errorf("want nil, got %v", err)
+		return
+	}
+}
+
+func TestReaderReadCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	internalReader, _ := io.Pipe()
+	reader := NewReader(internalReader, internalReader, ctx)
+
+	// NOTE: Do not use context.WithTimeout because several setup before ReadAll can take some duration.
+	go func() {
+		time.Sleep(time.Duration(100) * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := ioutil.ReadAll(reader)
+	if err != io.ErrClosedPipe {
+		t.Errorf("want io.ErrClosedPipe, got %v", err)
+		return
+	}
+}
+
+func TestReaderCloseAfterCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	internalReader, _ := io.Pipe()
+	reader := NewReader(internalReader, internalReader, ctx)
+
+	cancel()
+
+	if err := reader.Close(); err != nil {
+		t.Errorf("want nil, got %v", err)
+		return
+	}
+}

--- a/cmd/core/contextio/reader_test.go
+++ b/cmd/core/contextio/reader_test.go
@@ -13,7 +13,7 @@ func TestReaderRead(t *testing.T) {
 	reader := NewReader(internalReader, internalReader, context.Background())
 
 	go func() {
-		time.Sleep(time.Duration(100) * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 		_, _ = io.WriteString(internalWriter, "Hello")
 		_ = internalWriter.CloseWithError(io.EOF)
 	}()
@@ -33,7 +33,7 @@ func TestReaderReadCancel(t *testing.T) {
 
 	// NOTE: Do not use context.WithTimeout because several setup before ReadAll can take some duration.
 	go func() {
-		time.Sleep(time.Duration(100) * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 		cancel()
 	}()
 

--- a/cmd/core/exec/adb/ammonitor.go
+++ b/cmd/core/exec/adb/ammonitor.go
@@ -5,10 +5,10 @@ import (
 	"io"
 )
 
-type ActivityMonitor func(ctx context.Context, serialNumber SerialNumber, stdin io.ReadCloser, stdout io.Writer, stderr io.Writer) error
+type ActivityMonitor func(ctx context.Context, serialNumber SerialNumber, stdin io.Reader, stdout io.Writer, stderr io.Writer) error
 
 func NewActivityMonitor(adbCmd InteractiveExecutor) ActivityMonitor {
-	return func(ctx context.Context, serialNumber SerialNumber, stdin io.ReadCloser, stdout io.Writer, stderr io.Writer) error {
+	return func(ctx context.Context, serialNumber SerialNumber, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
 		// > monitor [options] Start monitoring for crashes or ANRs.
 		// > Options are:
 		// > --gdb: Start gdbserv on the given port at crash/ANR.

--- a/cmd/core/exec/adb/ammonitor_stub.go
+++ b/cmd/core/exec/adb/ammonitor_stub.go
@@ -1,0 +1,19 @@
+package adb
+
+import (
+	"context"
+	"io"
+)
+
+func StubAmMonitor(errCh <-chan error) ActivityMonitor {
+	return func(_ context.Context, _ SerialNumber, _ io.Reader, _ io.Writer, _ io.Writer) error {
+		return <-errCh
+	}
+}
+
+func FakeAmMonitor(err error) ActivityMonitor {
+	return func(ctx context.Context, _ SerialNumber, _ io.Reader, _ io.Writer, _ io.Writer) error {
+		<-ctx.Done()
+		return err
+	}
+}

--- a/cmd/core/exec/adb/ammonitorcrashwatcher.go
+++ b/cmd/core/exec/adb/ammonitorcrashwatcher.go
@@ -1,0 +1,39 @@
+package adb
+
+import (
+	"bufio"
+	"errors"
+	"github.com/dena/devfarm/cmd/core/logging"
+	"io"
+	"strings"
+)
+
+type AmMonitorCrashWatcher struct {
+	logger logging.SeverityLogger
+	stdout io.Reader
+}
+
+func NewAmMonitorCrashWatcher(logger logging.SeverityLogger, stdout io.Reader) *AmMonitorCrashWatcher {
+	return &AmMonitorCrashWatcher{logger: logger, stdout: stdout}
+}
+
+func (h AmMonitorCrashWatcher) Watch() error {
+	scanner := bufio.NewScanner(h.stdout)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		// > Monitoring activity manager...  available commands:
+		// > (q)uit: finish monitoring
+		// > ** ERROR: PROCESS CRASHED
+		// > processName: com.example.app
+		isCrashed := strings.Contains(line, "ERROR: PROCESS CRASHED")
+		if isCrashed {
+			msg := "am monitor: process crashed"
+			h.logger.Debug(msg)
+			return errors.New(msg)
+		}
+	}
+
+	h.logger.Debug("am monitor: process has never crashed")
+	return nil
+}

--- a/cmd/core/exec/adb/ammonitorcrashwatcher.go
+++ b/cmd/core/exec/adb/ammonitorcrashwatcher.go
@@ -21,12 +21,12 @@ func NewAmMonitorCrashWatcher(logger logging.SeverityLogger) AmMonitorCrashWatch
 			// > processName: com.example.app
 			isCrashed := strings.Contains(line, "ERROR: PROCESS CRASHED")
 			if isCrashed {
-				logger.Debug("am monitor: process crashed")
+				logger.Debug("am monitor: process got crashed")
 				return true
 			}
 		}
 
-		logger.Debug("am monitor: process has never crashed")
+		logger.Debug("am monitor: process had never got crashed")
 		return false
 	}
 }

--- a/cmd/core/exec/adb/ammonitorcrashwatcher.go
+++ b/cmd/core/exec/adb/ammonitorcrashwatcher.go
@@ -2,38 +2,31 @@ package adb
 
 import (
 	"bufio"
-	"errors"
 	"github.com/dena/devfarm/cmd/core/logging"
 	"io"
 	"strings"
 )
 
-type AmMonitorCrashWatcher struct {
-	logger logging.SeverityLogger
-	stdout io.Reader
-}
+type AmMonitorCrashWatcher func(reader io.Reader) (crashed bool)
 
-func NewAmMonitorCrashWatcher(logger logging.SeverityLogger, stdout io.Reader) *AmMonitorCrashWatcher {
-	return &AmMonitorCrashWatcher{logger: logger, stdout: stdout}
-}
+func NewAmMonitorCrashWatcher(logger logging.SeverityLogger) AmMonitorCrashWatcher {
+	return func(stdout io.Reader) (crashed bool) {
+		scanner := bufio.NewScanner(stdout)
 
-func (h AmMonitorCrashWatcher) Watch() error {
-	scanner := bufio.NewScanner(h.stdout)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		// > Monitoring activity manager...  available commands:
-		// > (q)uit: finish monitoring
-		// > ** ERROR: PROCESS CRASHED
-		// > processName: com.example.app
-		isCrashed := strings.Contains(line, "ERROR: PROCESS CRASHED")
-		if isCrashed {
-			msg := "am monitor: process crashed"
-			h.logger.Debug(msg)
-			return errors.New(msg)
+		for scanner.Scan() {
+			line := scanner.Text()
+			// > Monitoring activity manager...  available commands:
+			// > (q)uit: finish monitoring
+			// > ** ERROR: PROCESS CRASHED
+			// > processName: com.example.app
+			isCrashed := strings.Contains(line, "ERROR: PROCESS CRASHED")
+			if isCrashed {
+				logger.Debug("am monitor: process crashed")
+				return true
+			}
 		}
-	}
 
-	h.logger.Debug("am monitor: process has never crashed")
-	return nil
+		logger.Debug("am monitor: process has never crashed")
+		return false
+	}
 }

--- a/cmd/core/exec/adb/ammonitorcrashwatcher_stub.go
+++ b/cmd/core/exec/adb/ammonitorcrashwatcher_stub.go
@@ -1,0 +1,19 @@
+package adb
+
+import (
+	"io"
+	"io/ioutil"
+)
+
+func StubAmMonitorCrashWatcher(crashCh <-chan bool) AmMonitorCrashWatcher {
+	return func(_ io.Reader) (crashed bool) {
+		return <-crashCh
+	}
+}
+
+func FakeAmMonitorCrashWatcher(crashed bool) AmMonitorCrashWatcher {
+	return func(reader io.Reader) bool {
+		_, _ = ioutil.ReadAll(reader)
+		return crashed
+	}
+}

--- a/cmd/core/exec/adb/ammonitorcrashwatcher_test.go
+++ b/cmd/core/exec/adb/ammonitorcrashwatcher_test.go
@@ -1,0 +1,67 @@
+package adb
+
+import (
+	"github.com/dena/devfarm/cmd/core/logging"
+	"io"
+	"testing"
+	"time"
+)
+
+func TestAndroidWatcherNotCrashed(t *testing.T) {
+	spyLogger := logging.SpySeverityLogger()
+	stdoutReader, stdoutWriter := io.Pipe()
+
+	crashWatcher := NewAmMonitorCrashWatcher(spyLogger)
+
+	go func() {
+		_, _ = io.WriteString(stdoutWriter, startMsg)
+		time.Sleep(100 * time.Millisecond)
+		_ = stdoutWriter.Close()
+	}()
+
+	if crashed := crashWatcher(stdoutReader); crashed {
+		t.Log(spyLogger.Logs.String())
+		t.Error("got true, want false")
+		return
+	}
+}
+
+func TestAndroidWatcherCrashed(t *testing.T) {
+	spyLogger := logging.SpySeverityLogger()
+	stdoutReader, stdoutWriter := io.Pipe()
+
+	crashWatcher := NewAmMonitorCrashWatcher(spyLogger)
+
+	go func() {
+		_, _ = io.WriteString(stdoutWriter, startMsg)
+		time.Sleep(100 * time.Millisecond)
+		_, _ = io.WriteString(stdoutWriter, crashMsg)
+	}()
+
+	if crashed := crashWatcher(stdoutReader); !crashed {
+		t.Log(spyLogger.Logs.String())
+		t.Error("got false, want true")
+		return
+	}
+}
+
+var startMsg = `Monitoring activity manager...  available commands:
+(q)uit: finish monitoring
+`
+var crashMsg = `** ERROR: PROCESS CRASHED
+processName: com.example.apk
+processPid: 1234
+shortMsg: java.lang.RuntimeException
+longMsg: java.lang.RuntimeException
+timeMillis: 1568779503316
+stack:
+java.lang.RuntimeException
+...
+
+#
+
+Waiting after crash...  available commands:
+(c)ontinue: show crash dialog
+(k)ill: immediately kill app
+(q)uit: finish monitoring
+`

--- a/cmd/core/exec/adb/interactive.go
+++ b/cmd/core/exec/adb/interactive.go
@@ -8,7 +8,7 @@ import (
 
 type InteractiveExecutor func(ctx context.Context, stdin io.ReadCloser, stdout io.Writer, stderr io.Writer, args ...string) error
 
-func NewInteractiveExecutor(find exec.ExecutableFinder, execute exec.InteractiveExecutor) InteractiveExecutor {
+func NewInteractiveExecutor(find exec.ExecutableFinder, executor exec.InteractiveExecutor) InteractiveExecutor {
 	return func(ctx context.Context, stdin io.ReadCloser, stdout io.Writer, stderr io.Writer, args ...string) error {
 		if err := find("adb"); err != nil {
 			return &ExecutorError{NoSuchCommand: err}
@@ -24,7 +24,7 @@ func NewInteractiveExecutor(find exec.ExecutableFinder, execute exec.Interactive
 		// >    -P         port of adb server [default=5037]
 		// >    -L SOCKET  listen on given socket for adb server [default=tcp:localhost:5037]
 		req := exec.NewInteractiveRequest(stdin, stdout, stderr, "adb", args)
-		if err := execute(ctx, req); err != nil {
+		if err := executor.Execute(ctx, req); err != nil {
 			return &ExecutorError{UnexpectedExitStatus: err}
 		}
 

--- a/cmd/core/exec/adb/interactive.go
+++ b/cmd/core/exec/adb/interactive.go
@@ -6,10 +6,10 @@ import (
 	"io"
 )
 
-type InteractiveExecutor func(ctx context.Context, stdin io.ReadCloser, stdout io.Writer, stderr io.Writer, args ...string) error
+type InteractiveExecutor func(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writer, args ...string) error
 
 func NewInteractiveExecutor(find exec.ExecutableFinder, executor exec.InteractiveExecutor) InteractiveExecutor {
-	return func(ctx context.Context, stdin io.ReadCloser, stdout io.Writer, stderr io.Writer, args ...string) error {
+	return func(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writer, args ...string) error {
 		if err := find("adb"); err != nil {
 			return &ExecutorError{NoSuchCommand: err}
 		}

--- a/cmd/core/exec/interactive_stub.go
+++ b/cmd/core/exec/interactive_stub.go
@@ -5,11 +5,15 @@ import (
 	"github.com/dena/devfarm/cmd/core/testutil"
 )
 
-var AnySuccessfulInteractiveExecutor = StubInteractiveExecutor(nil)
-var AnyFailedInteractiveExecutor = StubInteractiveExecutor(testutil.AnyError)
+var AnySuccessfulInteractiveExecutor = &StubInteractiveExecutor{Err: nil}
+var AnyFailedInteractiveExecutor = &StubInteractiveExecutor{Err: testutil.AnyError}
 
-func StubInteractiveExecutor(err error) InteractiveExecutor {
-	return func(context.Context, InteractiveRequest) error {
-		return err
-	}
+type StubInteractiveExecutor struct {
+	Err error
+}
+
+var _ InteractiveExecutor = &StubInteractiveExecutor{}
+
+func (s *StubInteractiveExecutor) Execute(_ context.Context, _ InteractiveRequest) error {
+	return s.Err
 }

--- a/cmd/core/exec/interactive_test.go
+++ b/cmd/core/exec/interactive_test.go
@@ -26,7 +26,7 @@ func TestNewInteractiveExecutor(t *testing.T) {
 	}{
 		{
 			ctx: func() context.Context {
-				ctx, _ := context.WithTimeout(context.Background(), timeout)
+				ctx, _ := context.WithTimeout(context.Background(), timeout) // nolint:govet
 				return ctx
 			},
 			stdin:          strings.NewReader("hello"),
@@ -38,7 +38,7 @@ func TestNewInteractiveExecutor(t *testing.T) {
 		},
 		{
 			ctx: func() context.Context {
-				ctx, _ := context.WithTimeout(context.Background(), timeout)
+				ctx, _ := context.WithTimeout(context.Background(), timeout) // nolint:govet
 				return ctx
 			},
 			stdin:          nil,

--- a/cmd/core/exec/interactive_test.go
+++ b/cmd/core/exec/interactive_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestNewInteractiveExecutor(t *testing.T) {
+	timeout := 1000 * time.Millisecond
+
 	cases := []struct {
 		ctx            func() context.Context
 		stdin          io.Reader
@@ -24,13 +26,25 @@ func TestNewInteractiveExecutor(t *testing.T) {
 	}{
 		{
 			ctx: func() context.Context {
-				ctx, _ := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+				ctx, _ := context.WithTimeout(context.Background(), timeout)
 				return ctx
 			},
 			stdin:          strings.NewReader("hello"),
 			command:        "cat",
 			args:           []string{"-"},
 			expectedStdout: "hello",
+			expectedStderr: "",
+			expectedErr:    false,
+		},
+		{
+			ctx: func() context.Context {
+				ctx, _ := context.WithTimeout(context.Background(), timeout)
+				return ctx
+			},
+			stdin:          nil,
+			command:        "cat",
+			args:           []string{"-"},
+			expectedStdout: "",
 			expectedStderr: "",
 			expectedErr:    false,
 		},

--- a/cmd/core/logging/severitylogger_stub.go
+++ b/cmd/core/logging/severitylogger_stub.go
@@ -52,5 +52,5 @@ func (s *SeverityLoggerSpy) Error(message string) {
 }
 
 func (s *SeverityLoggerSpy) Log(severity Severity, message string) {
-	s.Logs.WriteString(fmt.Sprintf("%s: %s", string(severity), message))
+	s.Logs.WriteString(fmt.Sprintf("%s: %s\n", string(severity), message))
 }

--- a/cmd/core/platforms/awsdevicefarm/remoteagent/androidwatcher.go
+++ b/cmd/core/platforms/awsdevicefarm/remoteagent/androidwatcher.go
@@ -2,50 +2,58 @@ package remoteagent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/dena/devfarm/cmd/core/contextio"
 	"github.com/dena/devfarm/cmd/core/exec/adb"
 	"github.com/dena/devfarm/cmd/core/logging"
 	"io"
-	"io/ioutil"
-	"strings"
 	"time"
 )
 
 type androidWatcher func(serialNumber adb.SerialNumber, lifetime time.Duration) error
 
-func newAndroidWatcher(logger logging.SeverityLogger, amMonitor adb.ActivityMonitor) androidWatcher {
+func newAndroidWatcher(
+	logger logging.SeverityLogger,
+	amMonitor adb.ActivityMonitor,
+	crashWatcher adb.AmMonitorCrashWatcher,
+) androidWatcher {
 	return func(serialNumber adb.SerialNumber, lifetime time.Duration) error {
 		logger.Debug(fmt.Sprintf("android watcher: lifetime is %0.f sec", lifetime.Seconds()))
 
-		stdinReader := ioutil.NopCloser(strings.NewReader(""))
 		stdoutReader, stdoutWriter := io.Pipe()
 
-		errCh := make(chan error, 1 /* to prevent goroutine leak */)
-		ctx, cancelCmd := context.WithTimeout(context.Background(), lifetime+time.Minute)
+		crashCh := make(chan bool, 1 /* to prevent goroutines leak */)
+		ctx, cancelCmd := context.WithTimeout(context.Background(), lifetime)
 		defer cancelCmd()
 
 		go func() {
 			// NOTE: Make stdoutReader be cancelable.
 			reader := contextio.NewReader(stdoutReader, stdoutWriter, ctx)
-			crashWatcher := adb.NewAmMonitorCrashWatcher(logger, reader)
-			errCh <- crashWatcher.Watch()
+			crashCh <- crashWatcher(reader)
 		}()
 
 		logger.Debug("android watcher: starting am monitor")
-		if err := amMonitor(ctx, serialNumber, stdinReader, stdoutWriter, nil); err != nil {
+		if err := amMonitor(ctx, serialNumber, nil, stdoutWriter, nil); err != nil {
 			logger.Debug(fmt.Sprintf("android watcher: am monitor returned: %s", err.Error()))
 
 			// NOTE: Timeout should be treated as success, because the app has been alive until timeout exceeded.
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				logger.Debug(fmt.Sprintf("android watcher: context was canceled: %s", ctx.Err()))
+				// NOTE: Check whether the Android app was crashed or not.
+				if <-crashCh {
+					return androidCrashed
+				}
 				return nil
 			}
 
+			// NOTE: Early exit should be treated as failed, because it might be adb command error.
 			return err
 		}
 
-		// XXX: Check whether the Android app was crashed or not.
-		return <-errCh
+		// NOTE: App exit normally.
+		return nil
 	}
 }
+
+var androidCrashed = errors.New("android watcher: process crashed")

--- a/cmd/core/platforms/awsdevicefarm/remoteagent/androidwatcher.go
+++ b/cmd/core/platforms/awsdevicefarm/remoteagent/androidwatcher.go
@@ -1,13 +1,13 @@
 package remoteagent
 
 import (
-	"bufio"
 	"context"
-	"errors"
 	"fmt"
+	"github.com/dena/devfarm/cmd/core/contextio"
 	"github.com/dena/devfarm/cmd/core/exec/adb"
 	"github.com/dena/devfarm/cmd/core/logging"
 	"io"
+	"io/ioutil"
 	"strings"
 	"time"
 )
@@ -18,113 +18,34 @@ func newAndroidWatcher(logger logging.SeverityLogger, amMonitor adb.ActivityMoni
 	return func(serialNumber adb.SerialNumber, lifetime time.Duration) error {
 		logger.Debug(fmt.Sprintf("android watcher: lifetime is %0.f sec", lifetime.Seconds()))
 
-		stdinReader, stdinWriter := io.Pipe()
+		stdinReader := ioutil.NopCloser(strings.NewReader(""))
 		stdoutReader, stdoutWriter := io.Pipe()
-		stderrReader, stderrWriter := io.Pipe()
 
 		errCh := make(chan error, 1 /* to prevent goroutine leak */)
-		cmdCtx, cancelCmd := context.WithTimeout(context.Background(), lifetime+time.Minute /* to ensure exit */)
+		ctx, cancelCmd := context.WithTimeout(context.Background(), lifetime+time.Minute)
 		defer cancelCmd()
-		watchCtx, cancelWatch := context.WithTimeout(cmdCtx, lifetime)
-		defer cancelWatch()
 
 		go func() {
-			watcher := adbAmMonitorHandler{
-				logger: logger,
-				stdin:  stdinWriter,
-				stdout: stdoutReader,
-				stderr: stderrReader,
-			}
-			err := watcher.wait(watchCtx)
-			errCh <- err
-		}()
-
-		go func() {
-			<-watchCtx.Done()
-			logger.Debug(fmt.Sprintf("android watcher: lifetime (%0.f sec) exceeded", lifetime.Seconds()))
-			_ = stdoutWriter.Close()
+			// NOTE: Make stdoutReader be cancelable.
+			reader := contextio.NewReader(stdoutReader, stdoutWriter, ctx)
+			crashWatcher := adb.NewAmMonitorCrashWatcher(logger, reader)
+			errCh <- crashWatcher.Watch()
 		}()
 
 		logger.Debug("android watcher: starting am monitor")
-		if err := amMonitor(cmdCtx, serialNumber, stdinReader, stdoutWriter, stderrWriter); err != nil {
+		if err := amMonitor(ctx, serialNumber, stdinReader, stdoutWriter, nil); err != nil {
 			logger.Debug(fmt.Sprintf("android watcher: am monitor returned: %s", err.Error()))
-			select {
-			case <-watchCtx.Done():
-				logger.Debug(fmt.Sprintf("android watcher: canceled: %s", watchCtx.Err()))
-				// NOTE: Timeout should be treated as success, because the app has been alive until timeout exceeded.
-			default:
-				return err
-			}
-		}
 
-		// XXX: Check whether the Android app was crashed or not.
-		if err := <-errCh; err != nil {
+			// NOTE: Timeout should be treated as success, because the app has been alive until timeout exceeded.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				logger.Debug(fmt.Sprintf("android watcher: context was canceled: %s", ctx.Err()))
+				return nil
+			}
+
 			return err
 		}
 
-		return nil
+		// XXX: Check whether the Android app was crashed or not.
+		return <-errCh
 	}
-}
-
-type (
-	adbAmMonitorHandler struct {
-		logger logging.SeverityLogger
-		stdin  io.Writer
-		stdout io.Reader
-		stderr io.Reader
-	}
-	adbAmMonitorCommand string
-)
-
-func (h adbAmMonitorHandler) wait(ctx context.Context) error {
-	scanner := bufio.NewScanner(h.stdout)
-
-	defer func() {
-		if err := h.sendCommand(cmdIsQuit); err != nil {
-			msg := fmt.Sprintf("am monitor: failed to kill app: %q", err.Error())
-			h.logger.Error(msg)
-			panic(msg) // XXX: Force to exit the runner to exit adb.
-		}
-	}()
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		// > Monitoring activity manager...  available commands:
-		// > (q)uit: finish monitoring
-		// > ** ERROR: PROCESS CRASHED
-		// > processName: com.example.app
-		isCrashed := strings.Contains(line, "ERROR: PROCESS CRASHED")
-		if isCrashed {
-			h.logger.Debug("am monitor: process crashed")
-			return errors.New("process crashed")
-		}
-	}
-
-	h.logger.Debug("am monitor: process has never crashed")
-	return nil
-}
-
-func (h adbAmMonitorHandler) sendCommand(cmd adbAmMonitorCommand) error {
-	h.logger.Debug(fmt.Sprintf("am monitor: send command: %q", cmd))
-	if err := cmd.WriteTo(h.stdin); err != nil {
-		h.logger.Debug(fmt.Sprintf("am monitor: failed to send command: %q", cmd))
-		return err
-	}
-	return nil
-}
-
-const (
-	// > Waiting after crash...  available commands:
-	// > (c)ontinue: show crash dialog
-	// > (k)ill: immediately kill app
-	// > (q)uit: finish monitoring
-	cmdIsQuit adbAmMonitorCommand = "q"
-)
-
-func (c adbAmMonitorCommand) WriteTo(writer io.Writer) error {
-	_, err := io.WriteString(writer, fmt.Sprintf("%s\n", c))
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/cmd/core/platforms/awsdevicefarm/remoteagent/androidwatcher_test.go
+++ b/cmd/core/platforms/awsdevicefarm/remoteagent/androidwatcher_test.go
@@ -1,68 +1,101 @@
 package remoteagent
 
 import (
+	"errors"
 	"github.com/dena/devfarm/cmd/core/exec/adb"
 	"github.com/dena/devfarm/cmd/core/logging"
-	"io"
 	"testing"
 	"time"
 )
 
-func TestAndroidWatcherNotCrashed(t *testing.T) {
+func TestAndroidWatcherCrash(t *testing.T) {
+	// Timeline:
+	//   1. app launched via adb.
+	//   2. crashWatcher finished with true (means app get crashed) but adb is still alive.
+	//   3. watch() returns androidCrashed.
+	var serial adb.SerialNumber = "DUMMY"
+	lifetime := time.Second
+
 	spyLogger := logging.SpySeverityLogger()
-	stdoutReader, stdoutWriter := io.Pipe()
+	amMonitor := adb.FakeAmMonitor(errors.New("adb killed"))
+	crashCh := make(chan bool, 1)
+	crashCh <- true
+	crashWatcher := adb.StubAmMonitorCrashWatcher(crashCh)
 
-	crashWatcher := adb.NewAmMonitorCrashWatcher(spyLogger, stdoutReader)
+	watch := newAndroidWatcher(spyLogger, amMonitor, crashWatcher)
 
-	go func() {
-		_, _ = io.WriteString(stdoutWriter, startMsg)
-		time.Sleep(100 * time.Millisecond)
-		_ = stdoutWriter.Close()
-	}()
-
-	if err := crashWatcher.Watch(); err != nil {
-		t.Log(spyLogger.Logs.String())
-		t.Errorf("got %v, want nil", err)
+	if err := watch(serial, lifetime); err != androidCrashed {
+		t.Logf("\n%s", spyLogger.Logs.String())
+		t.Errorf("want androidCrashed, but %v", err)
 		return
 	}
 }
 
-func TestAndroidWatcherCrashed(t *testing.T) {
+func TestAndroidWatcherAlive(t *testing.T) {
+	// Timeline:
+	//   1. app launched via adb.
+	//   2. adb get killed because lifetime exceeded.
+	//   3. crashWatcher finished with false (means app had never been crashed) because stdout was closed.
+	//   4. watch() returns nil.
+	var serial adb.SerialNumber = "DUMMY"
+	lifetime := 100 * time.Millisecond
+
 	spyLogger := logging.SpySeverityLogger()
-	stdoutReader, stdoutWriter := io.Pipe()
+	amMonitor := adb.FakeAmMonitor(errors.New("adb killed"))
+	crashWatcher := adb.FakeAmMonitorCrashWatcher(false)
 
-	crashWatcher := adb.NewAmMonitorCrashWatcher(spyLogger, stdoutReader)
+	watch := newAndroidWatcher(spyLogger, amMonitor, crashWatcher)
 
-	go func() {
-		_, _ = io.WriteString(stdoutWriter, startMsg)
-		time.Sleep(100 * time.Millisecond)
-		_, _ = io.WriteString(stdoutWriter, crashMsg)
-	}()
-
-	if err := crashWatcher.Watch(); err == nil {
-		t.Log(spyLogger.Logs.String())
-		t.Error("got nil, want error")
+	if err := watch(serial, lifetime); err != nil {
+		t.Logf("\n%s", spyLogger.Logs.String())
+		t.Errorf("want nil, but %v", err)
 		return
 	}
 }
 
-var startMsg = `Monitoring activity manager...  available commands:
-(q)uit: finish monitoring
-`
-var crashMsg = `** ERROR: PROCESS CRASHED
-processName: com.example.apk
-processPid: 1234
-shortMsg: java.lang.RuntimeException
-longMsg: java.lang.RuntimeException
-timeMillis: 1568779503316
-stack:
-java.lang.RuntimeException
-...
+func TestAndroidWatcherAppNormalExit(t *testing.T) {
+	// Timeline:
+	//   1. app launched via adb.
+	//   2. adb exit because app exit.
+	//   3. crashWatcher finished with false (means not crashed) because stdout was closed.
+	//   4. watch() returns nil.
+	var serial adb.SerialNumber = "DUMMY"
+	lifetime := 100 * time.Millisecond
 
-#
+	spyLogger := logging.SpySeverityLogger()
+	amMonitor := adb.FakeAmMonitor(nil)
+	crashWatcher := adb.FakeAmMonitorCrashWatcher(false)
 
-Waiting after crash...  available commands:
-(c)ontinue: show crash dialog
-(k)ill: immediately kill app
-(q)uit: finish monitoring
-`
+	watch := newAndroidWatcher(spyLogger, amMonitor, crashWatcher)
+
+	if err := watch(serial, lifetime); err != nil {
+		t.Logf("\n%s", spyLogger.Logs.String())
+		t.Errorf("want nil, but %v", err)
+		return
+	}
+}
+
+func TestAndroidWatcherAdbErrorBeforeTimeout(t *testing.T) {
+	// Timeline:
+	//   1. try to launch app via adb.
+	//   2. adb exit abnormally soon.
+	//   3. crashWatcher finished with false (means not crashed) because stdout was closed.
+	//   4. watch() returns adb error.
+	var serial adb.SerialNumber = "DUMMY"
+	lifetime := time.Second
+
+	spyLogger := logging.SpySeverityLogger()
+	adbError := errors.New("command adb not found")
+	amMonitorErrCh := make(chan error, 1)
+	amMonitorErrCh <- adbError
+	amMonitor := adb.StubAmMonitor(amMonitorErrCh)
+	crashWatcher := adb.FakeAmMonitorCrashWatcher(false)
+
+	watch := newAndroidWatcher(spyLogger, amMonitor, crashWatcher)
+
+	if err := watch(serial, lifetime); err != adbError {
+		t.Logf("\n%s", spyLogger.Logs.String())
+		t.Errorf("want nil, but %v", err)
+		return
+	}
+}

--- a/cmd/core/platforms/awsdevicefarm/remoteagent/runner.go
+++ b/cmd/core/platforms/awsdevicefarm/remoteagent/runner.go
@@ -69,7 +69,11 @@ func NewRunner(bag RunnerBag) Runner {
 				adb.NewWaitUntilBecomeReady(adb.NewReadyDetector(getProp), exec.NewWaiter()),
 				adb.NewMainIntentFinder(adbCmd),
 				adb.NewActivityStarter(adbCmd),
-				newAndroidWatcher(bag.GetLogger(), adb.NewActivityMonitor(interactiveAdbCmd)),
+				newAndroidWatcher(
+					bag.GetLogger(),
+					adb.NewActivityMonitor(interactiveAdbCmd),
+					adb.NewAmMonitorCrashWatcher(bag.GetLogger()),
+				),
 			)
 			return runAndroidApp(platforms.AndroidIntentExtras(envVars.AppArgs), envVars.Lifetime)
 


### PR DESCRIPTION
```
stderr: (empty)
error: <nil>
android watcher: lifetime is 15 sec
android watcher: starting am monitor
find: "adb"
find (success): "/opt/dev/android-sdk-linux/platform-tools/adb"
interactive: ["adb" "-s" "94GX1Z8FX" "shell" "am" "monitor"]
stdout: "Monitoring activity manager...  available commands:\n"
stdout: "(q)uit: finish monitoring\n"
interactive: stdout closed
interactive: stderr closed
interactive: stdin closed
android watcher: lifetime (15 sec) exceeded
am monitor: process has never crashed
am monitor: send command: "q"
am monitor: failed to send command: "q"
am monitor: failed to kill app: "io: read/write on closed pipe"
panic: am monitor: failed to kill app: "io: read/write on closed pipe"
```